### PR TITLE
feat: add home network monitoring

### DIFF
--- a/apps/monitoring/chart.yaml
+++ b/apps/monitoring/chart.yaml
@@ -16,6 +16,8 @@ spec:
           prometheusSpec:
             serviceMonitorSelectorNilUsesHelmValues: false
             podMonitorSelectorNilUsesHelmValues: false
+            probeSelectorNilUsesHelmValues: false
+            probeNamespaceSelector: {}
             enableFeatures:
               - exemplar-storage
             storageSpec:
@@ -100,6 +102,10 @@ spec:
               allow_sign_up: true
               auto_login: true
               role_attribute_path: "[login=='stianfro'][0] && 'GrafanaAdmin' || 'Viewer'"
+
+          sidecar:
+            dashboards:
+              searchNamespace: ALL
 
           additionalDataSources:
             - name: Loki

--- a/apps/network-monitor/blackbox-exporter.yaml
+++ b/apps/network-monitor/blackbox-exporter.yaml
@@ -7,8 +7,8 @@ spec:
   project: default
   source:
     chart: prometheus-blackbox-exporter
-    repoURL: https://prometheus-community.github.io/helm-charts
-    targetRevision: 9.1.0
+    repoURL: ghcr.io/prometheus-community/charts
+    targetRevision: 11.9.1
     helm:
       releaseName: blackbox-exporter
       values: |
@@ -34,7 +34,13 @@ spec:
 
         securityContext:
           runAsUser: 0
+          runAsGroup: 0
+          runAsNonRoot: false
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
           capabilities:
+            drop:
+              - ALL
             add:
               - NET_RAW
 

--- a/apps/network-monitor/blackbox-exporter.yaml
+++ b/apps/network-monitor/blackbox-exporter.yaml
@@ -1,0 +1,48 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: blackbox-exporter-chart
+  namespace: argocd
+spec:
+  project: default
+  source:
+    chart: prometheus-blackbox-exporter
+    repoURL: https://prometheus-community.github.io/helm-charts
+    targetRevision: 9.1.0
+    helm:
+      releaseName: blackbox-exporter
+      values: |
+        config:
+          modules:
+            icmp:
+              prober: icmp
+              timeout: 5s
+              icmp:
+                preferred_ip_protocol: ip4
+            http_2xx:
+              prober: http
+              timeout: 10s
+              http:
+                preferred_ip_protocol: ip4
+                valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
+                valid_status_codes: []
+                follow_redirects: true
+                no_follow_redirects: false
+
+        podSecurityContext:
+          runAsNonRoot: false
+
+        securityContext:
+          runAsUser: 0
+          capabilities:
+            add:
+              - NET_RAW
+
+        serviceMonitor:
+          enabled: false
+  destination:
+    namespace: network-monitor
+    server: https://kubernetes.default.svc
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true

--- a/apps/network-monitor/dashboard.yaml
+++ b/apps/network-monitor/dashboard.yaml
@@ -1,0 +1,388 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: network-monitor-dashboard
+  namespace: network-monitor
+  labels:
+    grafana_dashboard: "1"
+data:
+  network-monitor.json: |
+    {
+      "annotations": {"list": []},
+      "editable": true,
+      "graphTooltip": 1,
+      "links": [],
+      "panels": [
+        {
+          "id": 1,
+          "type": "stat",
+          "title": "Internet (HTTP)",
+          "gridPos": {"h": 4, "w": 8, "x": 0, "y": 0},
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "center",
+            "orientation": "auto",
+            "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+            "textMode": "auto"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "mappings": [
+                {"type": "value", "options": {"0": {"color": "red", "index": 0, "text": "DOWN"}, "1": {"color": "green", "index": 1, "text": "UP"}}}
+              ],
+              "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "green", "value": 1}]},
+              "color": {"mode": "thresholds"},
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "expr": "min(probe_success{job=\"internet-http\"})",
+              "legendFormat": "HTTP",
+              "refId": "A"
+            }
+          ],
+          "datasource": {"type": "prometheus", "uid": "${datasource}"}
+        },
+        {
+          "id": 2,
+          "type": "stat",
+          "title": "Internet (ICMP)",
+          "gridPos": {"h": 4, "w": 8, "x": 8, "y": 0},
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "center",
+            "orientation": "auto",
+            "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+            "textMode": "auto"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "mappings": [
+                {"type": "value", "options": {"0": {"color": "red", "index": 0, "text": "DOWN"}, "1": {"color": "green", "index": 1, "text": "UP"}}}
+              ],
+              "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "green", "value": 1}]},
+              "color": {"mode": "thresholds"},
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "expr": "min(probe_success{job=\"internet-icmp\"})",
+              "legendFormat": "ICMP",
+              "refId": "A"
+            }
+          ],
+          "datasource": {"type": "prometheus", "uid": "${datasource}"}
+        },
+        {
+          "id": 3,
+          "type": "stat",
+          "title": "Gateway (192.168.1.1)",
+          "gridPos": {"h": 4, "w": 8, "x": 16, "y": 0},
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "center",
+            "orientation": "auto",
+            "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+            "textMode": "auto"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "mappings": [
+                {"type": "value", "options": {"0": {"color": "red", "index": 0, "text": "DOWN"}, "1": {"color": "green", "index": 1, "text": "UP"}}}
+              ],
+              "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "green", "value": 1}]},
+              "color": {"mode": "thresholds"},
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "expr": "probe_success{job=\"gateway-icmp\"}",
+              "legendFormat": "Gateway",
+              "refId": "A"
+            }
+          ],
+          "datasource": {"type": "prometheus", "uid": "${datasource}"}
+        },
+        {
+          "id": 4,
+          "type": "timeseries",
+          "title": "Connectivity (probe success over time)",
+          "description": "Shows internet and gateway connectivity blips. Drop to 0 = unreachable.",
+          "gridPos": {"h": 8, "w": 24, "x": 0, "y": 4},
+          "options": {
+            "tooltip": {"mode": "multi", "sort": "none"},
+            "legend": {"displayMode": "list", "placement": "bottom", "calcs": []},
+            "fillOpacity": 20
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "lineWidth": 2,
+                "fillOpacity": 20,
+                "spanNulls": false,
+                "drawStyle": "line",
+                "lineInterpolation": "stepAfter"
+              },
+              "min": 0,
+              "max": 1,
+              "mappings": [],
+              "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+              "color": {"mode": "palette-classic"}
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "expr": "probe_success{job=\"internet-http\"}",
+              "legendFormat": "HTTP: {{instance}}",
+              "refId": "A"
+            },
+            {
+              "expr": "probe_success{job=\"internet-icmp\"}",
+              "legendFormat": "ICMP: {{instance}}",
+              "refId": "B"
+            },
+            {
+              "expr": "probe_success{job=\"gateway-icmp\"}",
+              "legendFormat": "Gateway: {{instance}}",
+              "refId": "C"
+            }
+          ],
+          "datasource": {"type": "prometheus", "uid": "${datasource}"}
+        },
+        {
+          "id": 5,
+          "type": "timeseries",
+          "title": "ICMP Round-Trip Time",
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 12},
+          "options": {
+            "tooltip": {"mode": "multi", "sort": "none"},
+            "legend": {"displayMode": "list", "placement": "bottom", "calcs": ["mean", "max"]}
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {"lineWidth": 2, "fillOpacity": 10, "spanNulls": false, "drawStyle": "line"},
+              "unit": "s",
+              "color": {"mode": "palette-classic"}
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "expr": "probe_icmp_duration_seconds{phase=\"rtt\", job=\"internet-icmp\"}",
+              "legendFormat": "Internet: {{instance}}",
+              "refId": "A"
+            },
+            {
+              "expr": "probe_icmp_duration_seconds{phase=\"rtt\", job=\"gateway-icmp\"}",
+              "legendFormat": "Gateway: {{instance}}",
+              "refId": "B"
+            }
+          ],
+          "datasource": {"type": "prometheus", "uid": "${datasource}"}
+        },
+        {
+          "id": 6,
+          "type": "timeseries",
+          "title": "HTTP Probe Duration",
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 12},
+          "options": {
+            "tooltip": {"mode": "multi", "sort": "none"},
+            "legend": {"displayMode": "list", "placement": "bottom", "calcs": ["mean", "max"]}
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {"lineWidth": 2, "fillOpacity": 10, "spanNulls": false, "drawStyle": "line"},
+              "unit": "s",
+              "color": {"mode": "palette-classic"}
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "expr": "probe_duration_seconds{job=\"internet-http\"}",
+              "legendFormat": "{{instance}}",
+              "refId": "A"
+            }
+          ],
+          "datasource": {"type": "prometheus", "uid": "${datasource}"}
+        },
+        {
+          "id": 7,
+          "type": "timeseries",
+          "title": "Packet Loss (1h rolling window)",
+          "description": "Percentage of ICMP probes that failed over a 1-hour sliding window. Approximate packet loss.",
+          "gridPos": {"h": 8, "w": 24, "x": 0, "y": 20},
+          "options": {
+            "tooltip": {"mode": "multi", "sort": "none"},
+            "legend": {"displayMode": "list", "placement": "bottom", "calcs": ["mean", "max"]}
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {"lineWidth": 2, "fillOpacity": 10, "spanNulls": false, "drawStyle": "line"},
+              "unit": "percent",
+              "min": 0,
+              "max": 100,
+              "color": {"mode": "palette-classic"},
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 1}, {"color": "red", "value": 5}]
+              }
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "expr": "(1 - avg_over_time(probe_success{job=\"internet-icmp\", instance=\"8.8.8.8\"}[1h])) * 100",
+              "legendFormat": "8.8.8.8",
+              "refId": "A"
+            },
+            {
+              "expr": "(1 - avg_over_time(probe_success{job=\"internet-icmp\", instance=\"1.1.1.1\"}[1h])) * 100",
+              "legendFormat": "1.1.1.1",
+              "refId": "B"
+            },
+            {
+              "expr": "(1 - avg_over_time(probe_success{job=\"gateway-icmp\"}[1h])) * 100",
+              "legendFormat": "Gateway",
+              "refId": "C"
+            }
+          ],
+          "datasource": {"type": "prometheus", "uid": "${datasource}"}
+        },
+        {
+          "id": 8,
+          "type": "timeseries",
+          "title": "Speedtest Download",
+          "gridPos": {"h": 8, "w": 8, "x": 0, "y": 28},
+          "options": {
+            "tooltip": {"mode": "single", "sort": "none"},
+            "legend": {"displayMode": "list", "placement": "bottom", "calcs": ["last"]}
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "lineWidth": 2,
+                "fillOpacity": 20,
+                "spanNulls": true,
+                "drawStyle": "line",
+                "lineInterpolation": "smooth"
+              },
+              "unit": "bps",
+              "color": {"mode": "fixed", "fixedColor": "blue"}
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "expr": "speedtest_download_bits_per_second",
+              "legendFormat": "Download",
+              "refId": "A"
+            }
+          ],
+          "datasource": {"type": "prometheus", "uid": "${datasource}"}
+        },
+        {
+          "id": 9,
+          "type": "timeseries",
+          "title": "Speedtest Upload",
+          "gridPos": {"h": 8, "w": 8, "x": 8, "y": 28},
+          "options": {
+            "tooltip": {"mode": "single", "sort": "none"},
+            "legend": {"displayMode": "list", "placement": "bottom", "calcs": ["last"]}
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "lineWidth": 2,
+                "fillOpacity": 20,
+                "spanNulls": true,
+                "drawStyle": "line",
+                "lineInterpolation": "smooth"
+              },
+              "unit": "bps",
+              "color": {"mode": "fixed", "fixedColor": "orange"}
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "expr": "speedtest_upload_bits_per_second",
+              "legendFormat": "Upload",
+              "refId": "A"
+            }
+          ],
+          "datasource": {"type": "prometheus", "uid": "${datasource}"}
+        },
+        {
+          "id": 10,
+          "type": "timeseries",
+          "title": "Speedtest Ping",
+          "gridPos": {"h": 8, "w": 8, "x": 16, "y": 28},
+          "options": {
+            "tooltip": {"mode": "single", "sort": "none"},
+            "legend": {"displayMode": "list", "placement": "bottom", "calcs": ["last", "mean"]}
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "lineWidth": 2,
+                "fillOpacity": 10,
+                "spanNulls": true,
+                "drawStyle": "line",
+                "lineInterpolation": "smooth"
+              },
+              "unit": "ms",
+              "color": {"mode": "fixed", "fixedColor": "purple"}
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "expr": "speedtest_ping_latency_milliseconds",
+              "legendFormat": "Ping",
+              "refId": "A"
+            },
+            {
+              "expr": "speedtest_ping_jitter_milliseconds",
+              "legendFormat": "Jitter",
+              "refId": "B"
+            }
+          ],
+          "datasource": {"type": "prometheus", "uid": "${datasource}"}
+        }
+      ],
+      "refresh": "1m",
+      "schemaVersion": 38,
+      "tags": ["network", "monitoring", "internet"],
+      "templating": {
+        "list": [
+          {
+            "current": {},
+            "hide": 0,
+            "includeAll": false,
+            "label": "Datasource",
+            "name": "datasource",
+            "options": [],
+            "query": "prometheus",
+            "refresh": 1,
+            "type": "datasource"
+          }
+        ]
+      },
+      "time": {"from": "now-24h", "to": "now"},
+      "timepicker": {},
+      "timezone": "browser",
+      "title": "Network Monitoring",
+      "uid": "network-monitor-home",
+      "version": 1
+    }

--- a/apps/network-monitor/kustomization.yaml
+++ b/apps/network-monitor/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+  - namespace.yaml
+  - blackbox-exporter.yaml
+  - speedtest.yaml
+  - probes.yaml
+  - dashboard.yaml

--- a/apps/network-monitor/namespace.yaml
+++ b/apps/network-monitor/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: network-monitor
+  labels:
+    pod-security.kubernetes.io/enforce: privileged

--- a/apps/network-monitor/probes.yaml
+++ b/apps/network-monitor/probes.yaml
@@ -1,0 +1,61 @@
+---
+# Gateway ICMP reachability
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: gateway-icmp
+  namespace: network-monitor
+spec:
+  jobName: gateway-icmp
+  prober:
+    url: blackbox-exporter-prometheus-blackbox-exporter.network-monitor.svc.cluster.local:9115
+    path: /probe
+  module: icmp
+  interval: 15s
+  scrapeTimeout: 10s
+  targets:
+    staticConfig:
+      static:
+        - 192.168.1.1
+      labels:
+        target: gateway
+---
+# Internet ICMP connectivity
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: internet-icmp
+  namespace: network-monitor
+spec:
+  jobName: internet-icmp
+  prober:
+    url: blackbox-exporter-prometheus-blackbox-exporter.network-monitor.svc.cluster.local:9115
+    path: /probe
+  module: icmp
+  interval: 15s
+  scrapeTimeout: 10s
+  targets:
+    staticConfig:
+      static:
+        - 8.8.8.8
+        - 1.1.1.1
+---
+# Internet HTTP connectivity
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: internet-http
+  namespace: network-monitor
+spec:
+  jobName: internet-http
+  prober:
+    url: blackbox-exporter-prometheus-blackbox-exporter.network-monitor.svc.cluster.local:9115
+    path: /probe
+  module: http_2xx
+  interval: 30s
+  scrapeTimeout: 15s
+  targets:
+    staticConfig:
+      static:
+        - https://www.google.com
+        - https://one.one.one.one

--- a/apps/network-monitor/speedtest.yaml
+++ b/apps/network-monitor/speedtest.yaml
@@ -1,0 +1,77 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: speedtest-exporter
+  namespace: network-monitor
+  labels:
+    app.kubernetes.io/name: speedtest-exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: speedtest-exporter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: speedtest-exporter
+    spec:
+      containers:
+        - name: speedtest-exporter
+          image: ghcr.io/miguelndecarvalho/speedtest-exporter:v3.5.4
+          ports:
+            - name: metrics
+              containerPort: 9798
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 100m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 128Mi
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: metrics
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: metrics
+            initialDelaySeconds: 5
+            periodSeconds: 10
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: speedtest-exporter
+  namespace: network-monitor
+  labels:
+    app.kubernetes.io/name: speedtest-exporter
+spec:
+  selector:
+    app.kubernetes.io/name: speedtest-exporter
+  ports:
+    - name: metrics
+      port: 9798
+      targetPort: metrics
+      protocol: TCP
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: speedtest-exporter
+  namespace: network-monitor
+  labels:
+    app.kubernetes.io/name: speedtest-exporter
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: speedtest-exporter
+  endpoints:
+    - port: metrics
+      interval: 30m
+      scrapeTimeout: 2m
+      path: /metrics

--- a/apps/network-monitor/speedtest.yaml
+++ b/apps/network-monitor/speedtest.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: speedtest-exporter
-          image: ghcr.io/miguelndecarvalho/speedtest-exporter:v3.5.4
+          image: ghcr.io/miguelndecarvalho/speedtest-exporter:v3.5.4@sha256:f1064d49124c7fc45faabb87c6c876a2fd04e92b3dc14d4b871301217ba30fed
           ports:
             - name: metrics
               containerPort: 9798
@@ -32,13 +32,13 @@ spec:
               memory: 128Mi
           livenessProbe:
             httpGet:
-              path: /healthz
+              path: /
               port: metrics
             initialDelaySeconds: 10
             periodSeconds: 30
           readinessProbe:
             httpGet:
-              path: /healthz
+              path: /
               port: metrics
             initialDelaySeconds: 5
             periodSeconds: 10


### PR DESCRIPTION
## Summary

- Adds `apps/network-monitor/` with blackbox-exporter (Helm) for ICMP and HTTP probes targeting the gateway (192.168.1.1), Google DNS (8.8.8.8), Cloudflare DNS (1.1.1.1), and HTTP endpoints
- Deploys speedtest-exporter as a Deployment with a 30-minute scrape interval to track download/upload bandwidth and ping over time
- Creates Prometheus `Probe` CRDs for each monitored target
- Includes a Grafana dashboard ConfigMap with panels for: internet/gateway status (stat), connectivity blips (time series), ICMP RTT, HTTP probe duration, packet loss approximation (1h rolling window), and speedtest results
- Updates monitoring chart to discover Probes from all namespaces (`probeSelectorNilUsesHelmValues: false`) and Grafana sidecar to load dashboards from all namespaces (`searchNamespace: ALL`)

## Test plan

- [ ] Sync `network-monitor` app in Argo CD and verify `blackbox-exporter` and `speedtest-exporter` pods are Running
- [ ] Check Prometheus targets at `https://prometheus.talos.froystein.jp/targets` - look for `gateway-icmp`, `internet-icmp`, `internet-http`, and `speedtest-exporter` jobs
- [ ] Verify `probe_success` metrics exist in Prometheus
- [ ] Wait for at least one speedtest scrape (~30m) and verify `speedtest_download_bits_per_second` appears
- [ ] Open Grafana at `https://grafana.talos.froystein.jp` and confirm the "Network Monitoring" dashboard loads with data

🤖 Generated with [Claude Code](https://claude.com/claude-code)