### PR TITLE
feat(tcp-echo): test TCPRoute + cloudflared for non-HTTP services

### DIFF
--- a/apps/cloudflare-tunnel/configmap.yaml
+++ b/apps/cloudflare-tunnel/configmap.yaml
@@ -20,6 +20,8 @@ data:
       http2Origin: true
 
     ingress:
+      - hostname: "tcpecho.froystein.jp"
+        service: tcp://envoy-envoy-gateway-system-eg-public-7b646a69.envoy-gateway-system.svc.cluster.local:9000
       - hostname: "*.froystein.jp"
         service: http://envoy-envoy-gateway-system-eg-public-7b646a69.envoy-gateway-system.svc.cluster.local:80
       - hostname: "froystein.jp"

--- a/apps/gateway-public/gateway.yaml
+++ b/apps/gateway-public/gateway.yaml
@@ -54,6 +54,8 @@ spec:
       allowedRoutes:
         namespaces:
           from: All
+        kinds:
+          - kind: HTTPRoute
     - name: http-bare
       protocol: HTTP
       port: 80
@@ -61,3 +63,13 @@ spec:
       allowedRoutes:
         namespaces:
           from: All
+        kinds:
+          - kind: HTTPRoute
+    - name: tcp-echo
+      protocol: TCP
+      port: 9000
+      allowedRoutes:
+        namespaces:
+          from: All
+        kinds:
+          - kind: TCPRoute

--- a/apps/tcp-echo/deployment.yaml
+++ b/apps/tcp-echo/deployment.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tcp-echo
+  namespace: tcp-echo
+  labels:
+    app.kubernetes.io/name: tcp-echo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tcp-echo
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tcp-echo
+    spec:
+      containers:
+        - name: tcp-echo
+          image: istio/tcp-echo-server:1.3@sha256:782259608d5ce934e1a07ce4a3f2664934b6806d50430fd20b7bf429ea500272
+          imagePullPolicy: IfNotPresent
+          args:
+            - "9000"
+            - "hello"
+          ports:
+            - name: tcp
+              containerPort: 9000
+              protocol: TCP
+          readinessProbe:
+            tcpSocket:
+              port: tcp
+            periodSeconds: 5
+          livenessProbe:
+            tcpSocket:
+              port: tcp
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            capabilities:
+              drop:
+                - ALL

--- a/apps/tcp-echo/kustomization.yaml
+++ b/apps/tcp-echo/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+  - namespace.yaml
+  - deployment.yaml
+  - service.yaml
+  - tcproute.yaml

--- a/apps/tcp-echo/namespace.yaml
+++ b/apps/tcp-echo/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tcp-echo

--- a/apps/tcp-echo/service.yaml
+++ b/apps/tcp-echo/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: tcp-echo
+  namespace: tcp-echo
+  labels:
+    app.kubernetes.io/name: tcp-echo
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: tcp-echo
+  ports:
+    - name: tcp
+      port: 9000
+      targetPort: tcp
+      protocol: TCP

--- a/apps/tcp-echo/tcproute.yaml
+++ b/apps/tcp-echo/tcproute.yaml
@@ -1,0 +1,14 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TCPRoute
+metadata:
+  name: tcp-echo
+  namespace: tcp-echo
+spec:
+  parentRefs:
+    - name: eg-public
+      namespace: envoy-gateway-system
+      sectionName: tcp-echo
+  rules:
+    - backendRefs:
+        - name: tcp-echo
+          port: 9000


### PR DESCRIPTION
## Summary
- Proof of concept: expose a non-HTTP TCP service publicly via Envoy Gateway's `TCPRoute` + the existing `lab-public` Cloudflare Tunnel.
- Confirmed the existing tunnel can be reused — cloudflared supports mixed HTTP + TCP ingress rules in a single `config.yaml` (no second tunnel, no Spectrum needed).
- Adds a small `istio/tcp-echo-server:1.3` backend on port 9000, extends `eg-public` with a TCP listener, and adds a `tcpecho.froystein.jp` TCP ingress rule to the cloudflared ConfigMap.

## Changes
- `apps/tcp-echo/` (new): namespace, deployment, service, TCPRoute, kustomization
- `apps/gateway-public/gateway.yaml`: new `tcp-echo` TCP listener on port 9000; scope existing HTTP listeners to `kind: HTTPRoute` for clarity
- `apps/cloudflare-tunnel/configmap.yaml`: add `tcpecho.froystein.jp` -> `tcp://eg-public:9000` ingress rule (inserted before the HTTP wildcard)

## Post-merge / manual steps
- [ ] Sync `tcp-echo`, `gateway-public`, `cloudflare-tunnel` Argo CD apps
- [ ] `kubectl rollout restart deploy -n cloudflare-tunnel cloudflared` (ConfigMap isn't checksum-mounted)
- [ ] `cloudflared tunnel route dns --overwrite-dns lab-public tcpecho.froystein.jp`

## Test plan
- [ ] `kubectl get gateway -n envoy-gateway-system eg-public`: `tcp-echo` listener reports `Programmed=True`, Envoy Service now exposes port 9000
- [ ] `kubectl get tcproute -n tcp-echo tcp-echo`: parent `Accepted=True`
- [ ] In-cluster reachability: from any pod, `echo ping | nc tcp-echo.tcp-echo 9000` returns `hello ping`
- [ ] Through the gateway Service: `echo ping | nc envoy-envoy-gateway-system-eg-public-7b646a69.envoy-gateway-system 9000` returns `hello ping`
- [ ] DNS: `dig +short tcpecho.froystein.jp` returns a Cloudflare CNAME/IP
- [ ] End-to-end from a laptop:
  - Terminal A: `cloudflared access tcp --hostname tcpecho.froystein.jp --url localhost:9000`
  - Terminal B: `echo hi | nc localhost 9000` returns `hello hi`
- [ ] If terminal A errors about an Access policy, follow up with a self-hosted Access application backed by Authentik (same IdP as Kargo).